### PR TITLE
Add interesting features 🌟

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ module.exports = {
       files?: string[]; // Files, directories or glob patterns to watch for changes. (defaults to `[config.paths.sources]`, which itself defaults to the `contracts` dir)
       ignoredFiles?: string[]; // Files, directories or glob patterns that should *not* be watched.
       verbose?: boolean; // Turn on for extra logging
+      clearOnStart?: boolean; // Turn on to clear the logs (of older task runs) each time before running the task
+      start?: string; // Run any desirable command each time before the task runs
     }
   }
 };
@@ -80,6 +82,8 @@ module.exports = {
       files: ['./contracts'],
       ignoredFiles: ['**/.vscode'],
       verbose: true,
+      clearOnStart: true,
+      start: 'echo Running my compilation task now..'
     },
     ci: {
       tasks: [
@@ -130,7 +134,9 @@ module.exports = {
     test: {
       tasks: [{ command: 'test', params: { testFiles: ['{path}'] } }],
       files: ['./test/**/*'],
-      verbose: true
+      verbose: true,
+			clearOnStart: true,
+      start: 'echo Running my test task now..',
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ module.exports = {
       tasks: [{ command: 'test', params: { testFiles: ['{path}'] } }],
       files: ['./test/**/*'],
       verbose: true,
-			clearOnStart: true,
+      clearOnStart: true,
       start: 'echo Running my test task now..',
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { extendConfig, task } from 'hardhat/config'
 import { HardhatConfig, HardhatUserConfig, WatcherConfig } from 'hardhat/types'
 import chokidar from 'chokidar'
+const { execSync } = require('child_process')
 
 import './type-extensions'
 
@@ -27,6 +28,8 @@ extendConfig((config: HardhatConfig, userConfig: Readonly<HardhatUserConfig>) =>
       files: task.files ?? [config.paths.sources],
       ignoredFiles: task.ignoredFiles ?? [],
       verbose: task.verbose ?? false,
+      start: task.start ?? '',
+      clearOnStart: task.clearOnStart ?? false,
     }
   })
 
@@ -84,6 +87,19 @@ task('watch', 'Start the file watcher')
         interval: 250,
       })
       .on('change', async path => {
+        // Clear on on changed files received
+        if (taskConfig.clearOnStart) {
+          console.clear()
+        }
+        if (taskConfig.start) {
+          try {
+            execSync(taskConfig.start, { stdio: 'pipe' })
+          } catch (error) {
+            console.log("Faile to execute 'start' script:", taskConfig.start)
+            console.error(error)
+          }
+        }
+
         for (let i = 0; i < taskConfig.tasks.length; i++) {
           const task = taskConfig.tasks[i]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ task('watch', 'Start the file watcher')
           try {
             execSync(taskConfig.start, { stdio: 'inherit' })
           } catch (error) {
-            console.log("Faile to execute 'start' script:", taskConfig.start)
+            console.log("Failed to execute 'start' script:", taskConfig.start)
             console.error(error)
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ task('watch', 'Start the file watcher')
         }
         if (taskConfig.start) {
           try {
-            execSync(taskConfig.start, { stdio: 'pipe' })
+            execSync(taskConfig.start, { stdio: 'inherit' })
           } catch (error) {
             console.log("Faile to execute 'start' script:", taskConfig.start)
             console.error(error)

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -16,6 +16,8 @@ declare module 'hardhat/types/config' {
     files?: string[]
     ignoredFiles?: string[]
     verbose?: boolean
+    start?: string
+    clearOnStart?: boolean
   }
 
   // User facing config
@@ -29,6 +31,8 @@ declare module 'hardhat/types/config' {
       files: string[]
       ignoredFiles: string[]
       verbose: boolean
+      start?: string
+      clearOnStart?: boolean
     }
   }
 


### PR DESCRIPTION
Add support for running
1.) Custom start command before running the task via `start` option (inspired from [nodemon's api](https://github.com/remy/nodemon))
2.) Clear logs before every run of change files in the task event via `clearOnStart` option

So for adding those two options looks like:

```js
module.exports = {
	// ...
	  watcher: {
		  mycontracts: {
			  clearOnStart: true,
			  start: 'echo Staring my Sweet testing now!',
			  // ...
		  },
		  // ...
	  },
}
```

Thanks. I hope users of of this lib will like it as well. 